### PR TITLE
更好的创建自定义错误类型的方式

### DIFF
--- a/lib/JPush/JPushError.js
+++ b/lib/JPush/JPushError.js
@@ -7,23 +7,32 @@ exports.APIRequestError = APIRequestError
 exports.InvalidArgumentError = InvalidArgumentError
 
 function APIConnectionError (message, isResponseTimeout) {
-  Error.call(this, message)
   this.name = 'APIConnectionError'
   this.message = message
   this.isResponseTimeout = isResponseTimeout || false
+  this.stack = (new Error()).stack
 }
+
+APIConnectionError.prototype = Object.create(Error.prototype)
+APIConnectionError.prototype.constructor = APIConnectionError
 
 function APIRequestError (httpCode, response) {
   var message = 'Push Fail, HttpStatusCode: ' + httpCode + ' result: ' + response.toString()
-  Error.call(this, message)
   this.name = 'APIRequestError'
   this.message = message
   this.httpCode = httpCode
   this.response = response
+  this.stack = (new Error()).stack
 }
 
+APIRequestError.prototype = Object.create(Error.prototype)
+APIRequestError.prototype.constructor = APIRequestError
+
 function InvalidArgumentError (message) {
-  Error.call(this, message)
   this.name = 'InvalidArgumentError'
   this.message = message
+  this.stack = (new Error()).stack
 }
+
+InvalidArgumentError.prototype = Object.create(Error.prototype)
+InvalidArgumentError.prototype.constructor = InvalidArgumentError


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#Custom_Error_Types

之前的方法创建的错误不是 `Error` 的实例，也没 stack 信息