### PR TITLE
移除不必要的参数验证

### DIFF
--- a/lib/JPush/PushPayload.js
+++ b/lib/JPush/PushPayload.js
@@ -387,10 +387,6 @@ function generateSendno () {
 }
 
 function setOptions (sendno, time_to_live, override_msg_id, apns_production, big_push_duration, apns_collapse_id) {
-  if (sendno == null && time_to_live == null && override_msg_id == null && apns_production == null &&
-    big_push_duration == null) {
-    throw new JError.InvalidArgumentError("option's args cannot all be null.")
-  }
   var options = {}
 
   if (sendno != null) {


### PR DESCRIPTION
因为在向 options 添加设置前会做参数验证，同时
```
if (sendno != null) {
  if (typeof sendno !== 'number') {
    throw new JError.InvalidArgumentError('Invalid options.sendno, it can only be set to the Number')
  }
  options['sendno'] = sendno
} else {
  options['sendno'] = generateSendno()
}
```
类似这种判断事实上是允许参数为 null 的