### PR TITLE
updated debug and request to address security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "author": "jpush",
   "license": "MIT",
   "dependencies": {
-    "debug": "2.6.1",
-    "request": "~2.79.0",
+    "debug": "2.6.9",
+    "request": "^2.88.0",
     "request-promise": "^4.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Updated debug to version 2.6.9 and request to 2.88.0. 
More details please refer to issue: https://github.com/jpush/jpush-api-nodejs-client/issues/58
